### PR TITLE
look at exif data to determine image rotation settings

### DIFF
--- a/bulk_resize.py
+++ b/bulk_resize.py
@@ -16,8 +16,44 @@ max_height = 600
 
 WRITE_IMAGES = True
 
+# From https://stackoverflow.com/questions/4228530/pil-thumbnail-is-rotating-my-image
+def image_transpose_exif(im):
+    """
+    Apply Image.transpose to ensure 0th row of pixels is at the visual
+    top of the image, and 0th column is the visual left-hand side.
+    Return the original image if unable to determine the orientation.
+
+    As per CIPA DC-008-2012, the orientation field contains an integer,
+    1 through 8. Other values are reserved.
+
+    Parameters
+    ----------
+    im: PIL.Image
+       The image to be rotated.
+    """
+    exif_orientation_tag = 0x0112
+    exif_transpose_sequences = [                   # Val  0th row  0th col
+        [],                                        #  0    (reserved)
+        [],                                        #  1   top      left
+        [Image.FLIP_LEFT_RIGHT],                   #  2   top      right
+        [Image.ROTATE_180],                        #  3   bottom   right
+        [Image.FLIP_TOP_BOTTOM],                   #  4   bottom   left
+        [Image.FLIP_LEFT_RIGHT, Image.ROTATE_90],  #  5   left     top
+        [Image.ROTATE_270],                        #  6   right    top
+        [Image.FLIP_TOP_BOTTOM, Image.ROTATE_90],  #  7   right    bottom
+        [Image.ROTATE_90],                         #  8   left     bottom
+    ]
+
+    try:
+        seq = exif_transpose_sequences[im._getexif()[exif_orientation_tag]]
+    except Exception:
+        return im
+    else:
+        return functools.reduce(type(im).transpose, seq, im)
+
 def resizeImage(path, out_dir, max_width=max_width, max_height=max_height):
     im = Image.open(path)
+    im = image_transpose_exif(im)  # deal with EXIF rotation metadata
     bn = os.path.basename(path)
     ext = os.path.splitext(bn)[1]
     size = im.size


### PR DESCRIPTION
Was having a problem where output images were showing up with strange rotations in some cases.  This was a result images showing "proper" rotation was based on EXIF data in the images and when resizing the images this data was not preserved.  With this change  the native output image will be transposed/rotated as appropriate so that no EXIF data is required.